### PR TITLE
[TT-9694] Update autosuggest options' setter param types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "what3words"
+name = "what3words-api"
 description = "what3words API wrapper for rust"
 version = "0.1.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This function takes an instance of `what3words::ConvertToCoordinates` which acce
 Example:
 
 ```rust
-let convert_to_coordinates = what3words::ConvertToCoordinates::new("filled.count.soap");
+let convert_to_coordinates = what3words::ConvertToCoordinates::new("filled.count.soap").locale("zh_tr");
 ```
 
 > [!NOTE]
@@ -86,7 +86,7 @@ use what3words::{Address, AddressGeoJson, ConvertToCoordinates, What3words};
 
 let w3w = What3words::new("YOUR_API_KEY_HERE");
 
-let convert_to_coordinates = ConvertToCoordinates::new("filled.count.soap");
+let convert_to_coordinates = ConvertToCoordinates::new("產權.絕緣.墨鏡").locale("zh_tr");
 let address_json: Address = w3w.convert_to_coordinates::<Address>(&convert_to_coordinates);
 println!("{:?}", address_json.coordinates); // Coordinates { lat: 51.520847, lng: -0.195521 }
 
@@ -102,7 +102,7 @@ This function takes an instance of `what3words::ConvertTo3wa` which accepts a la
 Example:
 
 ```rust
-let convert_to_3wa = what3words::ConvertTo3wa::new(51.520847, -0.195521);
+let convert_to_3wa = what3words::ConvertTo3wa::new(51.520847, -0.195521).language("oo").locale("oo_cy");
 ```
 
 > [!NOTE]
@@ -119,9 +119,9 @@ use what3words::{Address, AddressGeoJson, ConvertTo3wa, What3words};
 let w3w = What3words::new("YOUR_API_KEY_HERE");
 
 
-let convert_to_3wa = ConvertTo3wa::new(51.520847, -0.195521);
+let convert_to_3wa = ConvertTo3wa::new(51.520847, -0.195521).language("mn").locale("mn_la");
 let address_json: Address = w3w.convert_to_3wa::<Address>(&convert_to_3wa);
-println!("{:?}", address_json.words); // "filled.count.soap"
+println!("{:?}", address_json.words); // "seruuhen.zemseg.dagaldah"
 
 let convert_to_3wa = ConvertTo3wa::new(51.520847, -0.195521);
 let address_geojson: Address = w3w.convert_to_3wa::<Address>(&convert_to_3wa);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # w3w-rust-wrapper
 
-A rust library to use the [what3words v3 API](https://docs.what3words.com/api/v3/).
+The official rust library for [what3words v3 API](https://docs.what3words.com/api/v3/).
 
 API methods are grouped into a single service object which can be centrally managed by a `What3words`instance.
 
@@ -25,7 +25,7 @@ To use this library you’ll need an API key, please visit [https://what3words.c
 To install what3words, simply:
 
 ```bash
-$ cargo add what3words
+$ cargo add what3words-api
 ```
 
 ## Features
@@ -33,7 +33,7 @@ $ cargo add what3words
 The functions are asynchronous by default, but this crate supports synchronous functions as well, simply enable `sync` feature when adding the crate to your project.
 
 ```bash
-cargo add what3words --features=sync
+cargo add what3words-api --features=sync
 ```
 
 > [!NOTE]
@@ -46,7 +46,7 @@ cargo add what3words --features=sync
 Once you have the API Key, you can initialise the wrapper like this:
 
 ```rust
-let wrapper = what3words::What3words::new("YOUR_API_KEY_HERE");
+let wrapper = what3words_api::What3words::new("YOUR_API_KEY_HERE");
 ```
 
 ### Optional
@@ -54,23 +54,23 @@ let wrapper = what3words::What3words::new("YOUR_API_KEY_HERE");
 You can also pass a different hostname if you have your own self-hosted what3words API.
 
 ```rust
-let wrapper = what3words::What3words::new("YOUR_API_KEY_HERE").hostname("https://your.what3words.api/v3");
+let wrapper = what3words_api::What3words::new("YOUR_API_KEY_HERE").hostname("https://your.what3words.api/v3");
 ```
 
 You can also set configure your own headers:
 
 ```rust
-let wrapper = what3words::What3words::new("YOUR_API_KEY_HERE").header("X-Foo", "Bar");
+let wrapper = what3words_api::What3words::new("YOUR_API_KEY_HERE").header("X-Foo", "Bar");
 ```
 
 ## Convert To Coordinates
 
-This function takes an instance of `what3words::ConvertToCoordinates` which accepts a string of 3 words `'filled.count.soap'`.
+This function takes an instance of `what3words_api::ConvertToCoordinates` which accepts a string of 3 words `'filled.count.soap'`.
 
 Example:
 
 ```rust
-let convert_to_coordinates = what3words::ConvertToCoordinates::new("filled.count.soap").locale("zh_tr");
+let convert_to_coordinates = what3words_api::ConvertToCoordinates::new("filled.count.soap").locale("zh_tr");
 ```
 
 > [!NOTE]
@@ -82,7 +82,7 @@ Example:
 > It is required to specify the type annotation for this function which will allow you to choose between `json` and `geojson` format. Using `Address` will use `json` (default) and `AddressGeoJson` will use `geojson`.
 
 ```rust
-use what3words::{Address, AddressGeoJson, ConvertToCoordinates, What3words};
+use what3words_api::{Address, AddressGeoJson, ConvertToCoordinates, What3words};
 
 let w3w = What3words::new("YOUR_API_KEY_HERE");
 
@@ -97,12 +97,12 @@ println!("{:?}", address_geojson.features); // [Feature { bbox: Some[-0.195543, 
 
 ## Convert To 3 Word Address
 
-This function takes an instance of `what3words::ConvertTo3wa` which accepts a latitude and longitude values (i.e.: `51.520847, -0.195521`):
+This function takes an instance of `what3words_api::ConvertTo3wa` which accepts a latitude and longitude values (i.e.: `51.520847, -0.195521`):
 
 Example:
 
 ```rust
-let convert_to_3wa = what3words::ConvertTo3wa::new(51.520847, -0.195521).language("oo").locale("oo_cy");
+let convert_to_3wa = what3words_api::ConvertTo3wa::new(51.520847, -0.195521).language("oo").locale("oo_cy");
 ```
 
 > [!NOTE]
@@ -114,7 +114,7 @@ Example:
 > It is required to specify the type annotation for this function which will allow you to choose between `json` and `geojson` format. Using `Address` will use `json` (default) and `AddressGeoJson` will use `geojson`.
 
 ```rust
-use what3words::{Address, AddressGeoJson, ConvertTo3wa, What3words};
+use what3words_api::{Address, AddressGeoJson, ConvertTo3wa, What3words};
 
 let w3w = What3words::new("YOUR_API_KEY_HERE");
 
@@ -156,28 +156,28 @@ https://docs.what3words.com/api/v3/#autosuggest
 > [!NOTE]
 > The returned payload from the `autosuggest` method is described in the [what3words REST API documentation](https://docs.what3words.com/api/v3/#autosuggest).
 
-This function takes an instance of `what3words::Autosuggest` which accepts a string of partial 3 words `'filled.count.so'`.
+This function takes an instance of `what3words_api::Autosuggest` which accepts a string of partial 3 words `'filled.count.so'`.
 
 Example:
 
 ```rust
-let autosuggest = what3words::Autosuggest::new("filled.count.so");
+let autosuggest = what3words_api::Autosuggest::new("filled.count.so");
 ```
 
-The instance of `what3words::Autosuggest` also allows you to set optional parameter(s) (i.e: clipping, focus, etc.):
+The instance of `what3words_api::Autosuggest` also allows you to set optional parameter(s) (i.e: clipping, focus, etc.):
 
 Examples:
 
 #### Focus
 
 ```rust
-let autosuggest = what3words::Autosuggest::new("filled.count.so").focus(&Coordinates::new(51.520847, -0.195521));
+let autosuggest = what3words_api::Autosuggest::new("filled.count.so").focus(&Coordinates::new(51.520847, -0.195521));
 ```
 
 #### Clipping
 
 ```rust
-let autosuggest = what3words::Autosuggest::new("filled.count.so")
+let autosuggest = what3words_api::Autosuggest::new("filled.count.so")
     .clip_to_country(&["GB","US"])
     .clip_to_bounding_box(&BoundingBox::new(
         51.521251, -0.203586, 51.521251, -0.203586,
@@ -193,7 +193,7 @@ let autosuggest = what3words::Autosuggest::new("filled.count.so")
 Example:
 
 ```rust
-use what3words::{Autosuggest, AutosuggestResult, What3words};
+use what3words_api::{Autosuggest, AutosuggestResult, What3words};
 
 let w3w = What3words::new("YOUR_API_KEY_HERE");
 
@@ -212,7 +212,7 @@ Example:
 > It is required to specify the type annotation for this function which will allow you to choose between `json` and `geojson` format. Using `GridSection` will use `json` (default) and `GridSectionGeoJson` will use `geojson`.
 
 ```rust
-use what3words::{BoundingBox, GridSection, GridSectionGeoJson, What3words};
+use what3words_api::{BoundingBox, GridSection, GridSectionGeoJson, What3words};
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -233,7 +233,7 @@ The returned payload from the `available-languages` method is described in the [
 Example:
 
 ```rust
-use what3words::{AvailableLanguages, What3words};
+use what3words_api::{AvailableLanguages, What3words};
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -255,7 +255,7 @@ This method takes a string as a parameter and determines if the string passed in
 Example:
 
 ```rust
-use what3words::What3words;
+use what3words_api::What3words;
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -278,7 +278,7 @@ This method takes a string as a parameter and returns whether the string is in t
 Example:
 
 ```rust
-use what3words::What3words;
+use what3words_api::What3words;
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -300,7 +300,7 @@ This method takes a string as a parameter and searches the string for any possib
 Example:
 
 ```rust
-use what3words::What3words;
+use what3words_api::What3words;
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -319,7 +319,7 @@ This method takes a string as a parameter and first passes it through the W3W re
 Example:
 
 ```rust
-use what3words::What3words;
+use what3words_api::What3words;
 
 let w3w: What3words = What3words::new("YOUR_API_KEY_HERE");
 
@@ -376,7 +376,7 @@ Anyone and everyone is welcome to contribute.
 
 ## Revision History
 
-- `0.1.0` 05/11/24 - Initial release
+- `0.1.0` 14/11/24 - Initial release
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,28 @@ let autosuggest = what3words::Autosuggest::new("filled.count.so");
 
 The instance of `what3words::Autosuggest` also allows you to set optional parameter(s) (i.e: clipping, focus, etc.):
 
-Example:
+Examples:
+
+#### Focus
 
 ```rust
 let autosuggest = what3words::Autosuggest::new("filled.count.so").focus(&Coordinates::new(51.520847, -0.195521));
+```
+
+#### Clipping
+
+```rust
+let autosuggest = what3words::Autosuggest::new("filled.count.so")
+    .clip_to_country(&["GB","US"])
+    .clip_to_bounding_box(&BoundingBox::new(
+        51.521251, -0.203586, 51.521251, -0.203586,
+    ))
+    .clip_to_circle(&Circle::new(51.521251, -0.203586, 1000))
+    .clip_to_polygon(&Polygon::new(&[
+        Coordinates::new(51.521251, -0.203586),
+        Coordinates::new(51.521251, -0.203586),
+        Coordinates::new(51.521251, -0.203581),
+    ]));
 ```
 
 Example:

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,12 +1,12 @@
 use std::env;
 
-use what3words::{
+use what3words_api::{
     Address, AddressGeoJson, Autosuggest, AutosuggestSelection, BoundingBox, ConvertTo3wa,
     ConvertToCoordinates, Coordinates, GridSection, GridSectionGeoJson, What3words,
 };
 
 #[::tokio::main]
-async fn main() -> Result<(), what3words::Error> {
+async fn main() -> Result<(), what3words_api::Error> {
     let api_key = env::var("W3W_API_KEY").expect(
         "Please ensure that W3W_API_KEY is added to your environment variables.\nRun `W3W_API_KEY=<YOUR_API_KEY> cargo run --example wrapper-demo` from bash/zsh or `$Env:W3W_API_KEY=<YOUR_API_KEY>; cargo run --example wrapper-demo` from PowerShell.",
     );

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use what3words::{
+use what3words_api::{
     Address, AddressGeoJson, Autosuggest, AutosuggestSelection, BoundingBox, ConvertTo3wa,
     ConvertToCoordinates, Coordinates, Error, GridSection, GridSectionGeoJson, What3words,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@ pub use self::models::{
     autosuggest::{Autosuggest, AutosuggestResult, AutosuggestSelection, Suggestion},
     gridsection::{BoundingBox, GridSection, GridSectionGeoJson},
     language::{AvailableLanguages, Language},
-    location::{Address, AddressGeoJson, ConvertTo3wa, ConvertToCoordinates, Coordinates, Square},
+    location::{
+        Address, AddressGeoJson, Circle, ConvertTo3wa, ConvertToCoordinates, Coordinates, Polygon,
+        Square,
+    },
 };
 pub use self::service::{Error, What3words};
 

--- a/src/models/autosuggest.rs
+++ b/src/models/autosuggest.rs
@@ -1,8 +1,6 @@
+use super::gridsection::BoundingBox;
 use super::location::{Circle, Coordinates, Polygon, Square};
-use crate::{
-    service::{Error, ToHashMap, Validator},
-    BoundingBox,
-};
+use crate::service::{Error, ToHashMap, Validator};
 use serde::Deserialize;
 use std::{collections::HashMap, fmt};
 

--- a/src/models/autosuggest.rs
+++ b/src/models/autosuggest.rs
@@ -1,26 +1,39 @@
-use super::location::{Coordinates, Square};
-use crate::service::ToHashMap;
+use super::location::{Circle, Coordinates, Polygon, Square};
+use crate::{
+    service::{Error, ToHashMap, Validator},
+    BoundingBox,
+};
 use serde::Deserialize;
 use std::{collections::HashMap, fmt};
 
 #[derive(Debug, Clone)]
 pub struct Autosuggest {
-    pub input: Option<String>,
-    pub n_results: Option<String>,
-    pub focus: Option<String>,
-    pub n_focus_result: Option<String>,
-    pub clip_to_country: Option<String>,
-    pub clip_to_bounding_box: Option<String>,
-    pub clip_to_circle: Option<String>,
-    pub clip_to_polygon: Option<String>,
-    pub input_type: Option<String>,
-    pub language: Option<String>,
-    pub prefer_land: Option<bool>,
-    pub locale: Option<String>,
+    input: Option<String>,
+    n_results: Option<String>,
+    focus: Option<String>,
+    n_focus_result: Option<String>,
+    clip_to_country: Option<String>,
+    clip_to_bounding_box: Option<BoundingBox>,
+    clip_to_circle: Option<Circle>,
+    clip_to_polygon: Option<Polygon>,
+    input_type: Option<String>,
+    language: Option<String>,
+    prefer_land: Option<bool>,
+    locale: Option<String>,
+}
+
+impl Validator for Autosuggest {
+    fn validate(&self) -> std::result::Result<(), Error> {
+        if let Some(ref clip_to_polygon) = &self.clip_to_polygon {
+            clip_to_polygon.validate()?;
+        }
+        Ok(())
+    }
 }
 
 impl ToHashMap for Autosuggest {
-    fn to_hash_map<'a>(&self) -> HashMap<&'a str, String> {
+    fn to_hash_map<'a>(&self) -> Result<HashMap<&'a str, String>, Error> {
+        self.validate()?;
         let mut map = HashMap::new();
         if let Some(ref input) = &self.input {
             map.insert("input", input.into());
@@ -38,13 +51,13 @@ impl ToHashMap for Autosuggest {
             map.insert("clip-to-country", clip_to_country.into());
         }
         if let Some(ref clip_to_bounding_box) = &self.clip_to_bounding_box {
-            map.insert("clip-to-bounding-box", clip_to_bounding_box.into());
+            map.insert("clip-to-bounding-box", clip_to_bounding_box.to_string());
         }
         if let Some(ref clip_to_circle) = &self.clip_to_circle {
-            map.insert("clip-to-circle", clip_to_circle.into());
+            map.insert("clip-to-circle", clip_to_circle.to_string());
         }
         if let Some(ref clip_to_polygon) = &self.clip_to_polygon {
-            map.insert("clip-to-polygon", clip_to_polygon.into());
+            map.insert("clip-to-polygon", clip_to_polygon.to_string());
         }
         if let Some(ref input_type) = &self.input_type {
             map.insert("input-type", input_type.into());
@@ -58,7 +71,7 @@ impl ToHashMap for Autosuggest {
         if let Some(ref prefer_land) = &self.prefer_land {
             map.insert("prefer-land", prefer_land.to_string());
         }
-        map
+        Ok(map)
     }
 }
 
@@ -94,23 +107,28 @@ impl Autosuggest {
         self
     }
 
-    pub fn clip_to_country(mut self, clip_to_country: impl Into<String>) -> Self {
-        self.clip_to_country = Some(clip_to_country.into());
+    pub fn clip_to_country(mut self, clip_to_country: &[impl Into<String> + Clone]) -> Self {
+        let countries = clip_to_country
+            .iter()
+            .map(|c| c.clone().into())
+            .collect::<Vec<String>>()
+            .join(",");
+        self.clip_to_country = Some(countries);
         self
     }
 
-    pub fn clip_to_bounding_box(mut self, clip_to_bounding_box: impl Into<String>) -> Self {
-        self.clip_to_bounding_box = Some(clip_to_bounding_box.into());
+    pub fn clip_to_bounding_box(mut self, clip_to_bounding_box: &BoundingBox) -> Self {
+        self.clip_to_bounding_box = Some(clip_to_bounding_box.clone());
         self
     }
 
-    pub fn clip_to_circle(mut self, clip_to_circle: impl Into<String>) -> Self {
-        self.clip_to_circle = Some(clip_to_circle.into());
+    pub fn clip_to_circle(mut self, clip_to_circle: &Circle) -> Self {
+        self.clip_to_circle = Some(clip_to_circle.clone());
         self
     }
 
-    pub fn clip_to_polygon(mut self, clip_to_polygon: impl Into<String>) -> Self {
-        self.clip_to_polygon = Some(clip_to_polygon.into());
+    pub fn clip_to_polygon(mut self, clip_to_polygon: &Polygon) -> Self {
+        self.clip_to_polygon = Some(clip_to_polygon.clone());
         self
     }
 
@@ -143,13 +161,13 @@ impl fmt::Display for Autosuggest {
 
 #[derive(Debug, Clone)]
 pub struct AutosuggestSelection {
-    pub raw_input: Option<String>,
-    pub options: Option<Autosuggest>,
-    pub suggestion: Option<Suggestion>,
+    raw_input: Option<String>,
+    options: Option<Autosuggest>,
+    suggestion: Option<Suggestion>,
 }
 
 impl ToHashMap for AutosuggestSelection {
-    fn to_hash_map<'a>(&self) -> HashMap<&'a str, String> {
+    fn to_hash_map<'a>(&self) -> Result<HashMap<&'a str, String>, Error> {
         let mut map = HashMap::new();
         if let Some(ref raw_input) = &self.raw_input {
             map.insert("raw-input", raw_input.clone());
@@ -159,10 +177,10 @@ impl ToHashMap for AutosuggestSelection {
             map.insert("selection", suggestion.words.clone());
         }
         if let Some(ref options) = &self.options {
-            let options_map = options.to_hash_map();
+            let options_map = options.to_hash_map()?;
             map.extend(options_map);
         }
-        map
+        Ok(map)
     }
 }
 
@@ -213,10 +231,16 @@ mod autosuggest_tests {
                 lng: -0.203586,
             })
             .n_focus_result("3")
-            .clip_to_country("GB")
-            .clip_to_bounding_box("51.521251,-0.203586,51.521251,-0.203586")
-            .clip_to_circle("51.521251,-0.203586,1000")
-            .clip_to_polygon("51.521251,-0.203586,51.521251,-0.203586,51.521251,-0.203586")
+            .clip_to_country(&["GB"])
+            .clip_to_bounding_box(&BoundingBox::new(
+                51.521251, -0.203586, 51.521251, -0.203586,
+            ))
+            .clip_to_circle(&Circle::new(51.521251, -0.203586, 1000))
+            .clip_to_polygon(&Polygon::new(vec![
+                Coordinates::new(51.521251, -0.203586),
+                Coordinates::new(51.521251, -0.203586),
+                Coordinates::new(51.521251, -0.203581),
+            ]))
             .input_type("text")
             .language("en")
             .prefer_land(true)
@@ -224,7 +248,7 @@ mod autosuggest_tests {
 
         assert_eq!(
                     format!("{}", autosuggest),
-                    "Autosuggest { input: Some(\"test input\"), n_results: Some(\"5\"), focus: Some(\"51.521251,-0.203586\"), n_focus_result: Some(\"3\"), clip_to_country: Some(\"GB\"), clip_to_bounding_box: Some(\"51.521251,-0.203586,51.521251,-0.203586\"), clip_to_circle: Some(\"51.521251,-0.203586,1000\"), clip_to_polygon: Some(\"51.521251,-0.203586,51.521251,-0.203586,51.521251,-0.203586\"), input_type: Some(\"text\"), language: Some(\"en\"), prefer_land: Some(true), locale: Some(\"en-GB\") }"
+                    "Autosuggest { input: Some(\"test input\"), n_results: Some(\"5\"), focus: Some(\"51.521251,-0.203586\"), n_focus_result: Some(\"3\"), clip_to_country: Some(\"GB\"), clip_to_bounding_box: Some(BoundingBox { southwest: Coordinates { lat: 51.521251, lng: -0.203586 }, northeast: Coordinates { lat: 51.521251, lng: -0.203586 } }), clip_to_circle: Some(Circle { lat: 51.521251, lng: -0.203586, radius: 1000 }), clip_to_polygon: Some(Polygon { coordinates: [Coordinates { lat: 51.521251, lng: -0.203586 }, Coordinates { lat: 51.521251, lng: -0.203586 }, Coordinates { lat: 51.521251, lng: -0.203581 }] }), input_type: Some(\"text\"), language: Some(\"en\"), prefer_land: Some(true), locale: Some(\"en-GB\") }"
                 );
     }
 
@@ -237,37 +261,96 @@ mod autosuggest_tests {
                 lng: -0.203586,
             })
             .n_focus_result("3")
-            .clip_to_country("GB")
-            .clip_to_bounding_box("51.521251,-0.203586,51.521251,-0.203586")
-            .clip_to_circle("51.521251,-0.203586,1000")
-            .clip_to_polygon("51.521251,-0.203586,51.521251,-0.203586,51.521251,-0.203586")
+            .clip_to_country(&["GB"])
+            .clip_to_bounding_box(&BoundingBox::new(
+                51.521251, -0.203586, 51.521251, -0.203586,
+            ))
+            .clip_to_circle(&Circle::new(51.521251, -0.203586, 1000))
+            .clip_to_polygon(&Polygon::new(vec![
+                Coordinates::new(51.521251, -0.203586),
+                Coordinates::new(51.521251, -0.203586),
+                Coordinates::new(51.521251, -0.203586),
+            ]))
             .input_type("text")
             .language("en")
             .prefer_land(true)
             .locale("en-GB");
 
-        let map = autosuggest.to_hash_map();
-        assert_eq!(map.get("input"), Some(&"test input".to_string()));
-        assert_eq!(map.get("n-results"), Some(&"5".to_string()));
-        assert_eq!(map.get("focus"), Some(&"51.521251,-0.203586".to_string()));
-        assert_eq!(map.get("n-focus-result"), Some(&"3".to_string()));
-        assert_eq!(map.get("clip-to-country"), Some(&"GB".to_string()));
-        assert_eq!(
-            map.get("clip-to-bounding-box"),
-            Some(&"51.521251,-0.203586,51.521251,-0.203586".to_string())
-        );
-        assert_eq!(
-            map.get("clip-to-circle"),
-            Some(&"51.521251,-0.203586,1000".to_string())
-        );
-        assert_eq!(
-            map.get("clip-to-polygon"),
-            Some(&"51.521251,-0.203586,51.521251,-0.203586,51.521251,-0.203586".to_string())
-        );
-        assert_eq!(map.get("input-type"), Some(&"text".to_string()));
-        assert_eq!(map.get("language"), Some(&"en".to_string()));
-        assert_eq!(map.get("prefer-land"), Some(&"true".to_string()));
-        assert_eq!(map.get("locale"), Some(&"en-GB".to_string()));
+        if let Ok(map) = autosuggest.to_hash_map() {
+            assert_eq!(map.get("input"), Some(&"test input".to_string()));
+            assert_eq!(map.get("n-results"), Some(&"5".to_string()));
+            assert_eq!(map.get("focus"), Some(&"51.521251,-0.203586".to_string()));
+            assert_eq!(map.get("n-focus-result"), Some(&"3".to_string()));
+            assert_eq!(map.get("clip-to-country"), Some(&"GB".to_string()));
+            assert_eq!(
+                map.get("clip-to-bounding-box"),
+                Some(&"51.521251,-0.203586,51.521251,-0.203586".to_string())
+            );
+            assert_eq!(
+                map.get("clip-to-circle"),
+                Some(&"51.521251,-0.203586,1000".to_string())
+            );
+            assert_eq!(
+                map.get("clip-to-polygon"),
+                Some(&"51.521251,-0.203586,51.521251,-0.203586,51.521251,-0.203586".to_string())
+            );
+            assert_eq!(map.get("input-type"), Some(&"text".to_string()));
+            assert_eq!(map.get("language"), Some(&"en".to_string()));
+            assert_eq!(map.get("prefer-land"), Some(&"true".to_string()));
+            assert_eq!(map.get("locale"), Some(&"en-GB".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_autosuggest_validator() {
+        // Test valid polygon
+        let autosuggest = Autosuggest::new("test input").clip_to_polygon(&Polygon::new(vec![
+            Coordinates::new(51.521251, -0.203586),
+            Coordinates::new(51.521251, -0.203586),
+            Coordinates::new(51.521251, -0.203581),
+            Coordinates::new(51.521251, -0.203586),
+        ]));
+        assert!(autosuggest.validate().is_ok());
+
+        let invalid_autosuggest =
+            Autosuggest::new("test input").clip_to_polygon(&Polygon::new(vec![
+                Coordinates::new(51.521251, -0.203586),
+                Coordinates::new(51.521251, -0.203586),
+            ]));
+        assert!(invalid_autosuggest.validate().is_err());
+    }
+
+    #[test]
+    fn test_autosuggest_empty() {
+        let autosuggest = Autosuggest::new("");
+        if let Ok(map) = autosuggest.to_hash_map() {
+            assert_eq!(map.get("input"), Some(&"".to_string()));
+            assert_eq!(map.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_autosuggest_selection_empty() {
+        let suggestion = Suggestion {
+            country: "".to_string(),
+            nearest_place: "".to_string(),
+            words: "".to_string(),
+            rank: 0,
+            language: "".to_string(),
+            distance_to_focus_km: None,
+            square: None,
+            coordinates: None,
+            map: None,
+        };
+
+        let selection = AutosuggestSelection::new("", &suggestion);
+
+        if let Ok(map) = selection.to_hash_map() {
+            assert_eq!(map.get("raw-input"), Some(&"".to_string()));
+            assert_eq!(map.get("rank"), Some(&"0".to_string()));
+            assert_eq!(map.get("selection"), Some(&"".to_string()));
+            assert_eq!(map.len(), 3);
+        }
     }
 
     #[test]
@@ -293,12 +376,13 @@ mod autosuggest_tests {
 
         let selection = AutosuggestSelection::new("test input", &suggestion).options(&autosuggest);
 
-        let map = selection.to_hash_map();
-        assert_eq!(map.get("raw-input"), Some(&"test input".to_string()));
-        assert_eq!(map.get("rank"), Some(&"1".to_string()));
-        assert_eq!(map.get("selection"), Some(&"index.home.raft".to_string()));
-        assert_eq!(map.get("input"), Some(&"test input".to_string()));
-        assert_eq!(map.get("n-results"), Some(&"5".to_string()));
-        assert_eq!(map.get("focus"), Some(&"51.521251,-0.203586".to_string()));
+        if let Ok(map) = selection.to_hash_map() {
+            assert_eq!(map.get("raw-input"), Some(&"test input".to_string()));
+            assert_eq!(map.get("rank"), Some(&"1".to_string()));
+            assert_eq!(map.get("selection"), Some(&"index.home.raft".to_string()));
+            assert_eq!(map.get("input"), Some(&"test input".to_string()));
+            assert_eq!(map.get("n-results"), Some(&"5".to_string()));
+            assert_eq!(map.get("focus"), Some(&"51.521251,-0.203586".to_string()));
+        }
     }
 }

--- a/src/models/autosuggest.rs
+++ b/src/models/autosuggest.rs
@@ -234,7 +234,7 @@ mod autosuggest_tests {
                 51.521251, -0.203586, 51.521251, -0.203586,
             ))
             .clip_to_circle(&Circle::new(51.521251, -0.203586, 1000))
-            .clip_to_polygon(&Polygon::new(vec![
+            .clip_to_polygon(&Polygon::new(&[
                 Coordinates::new(51.521251, -0.203586),
                 Coordinates::new(51.521251, -0.203586),
                 Coordinates::new(51.521251, -0.203581),
@@ -264,7 +264,7 @@ mod autosuggest_tests {
                 51.521251, -0.203586, 51.521251, -0.203586,
             ))
             .clip_to_circle(&Circle::new(51.521251, -0.203586, 1000))
-            .clip_to_polygon(&Polygon::new(vec![
+            .clip_to_polygon(&Polygon::new(&[
                 Coordinates::new(51.521251, -0.203586),
                 Coordinates::new(51.521251, -0.203586),
                 Coordinates::new(51.521251, -0.203586),
@@ -302,7 +302,7 @@ mod autosuggest_tests {
     #[test]
     fn test_autosuggest_validator() {
         // Test valid polygon
-        let autosuggest = Autosuggest::new("test input").clip_to_polygon(&Polygon::new(vec![
+        let autosuggest = Autosuggest::new("test input").clip_to_polygon(&Polygon::new(&[
             Coordinates::new(51.521251, -0.203586),
             Coordinates::new(51.521251, -0.203586),
             Coordinates::new(51.521251, -0.203581),
@@ -310,11 +310,10 @@ mod autosuggest_tests {
         ]));
         assert!(autosuggest.validate().is_ok());
 
-        let invalid_autosuggest =
-            Autosuggest::new("test input").clip_to_polygon(&Polygon::new(vec![
-                Coordinates::new(51.521251, -0.203586),
-                Coordinates::new(51.521251, -0.203586),
-            ]));
+        let invalid_autosuggest = Autosuggest::new("test input").clip_to_polygon(&Polygon::new(&[
+            Coordinates::new(51.521251, -0.203586),
+            Coordinates::new(51.521251, -0.203586),
+        ]));
         assert!(invalid_autosuggest.validate().is_err());
     }
 

--- a/src/models/gridsection.rs
+++ b/src/models/gridsection.rs
@@ -47,7 +47,7 @@ pub struct Geometry {
     pub kind: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundingBox {
     southwest: Coordinates,
     northeast: Coordinates,

--- a/src/models/location.rs
+++ b/src/models/location.rs
@@ -130,8 +130,10 @@ pub struct Polygon {
 }
 
 impl Polygon {
-    pub fn new(coordinates: Vec<Coordinates>) -> Self {
-        Self { coordinates }
+    pub fn new(coordinates: &[Coordinates]) -> Self {
+        Self {
+            coordinates: coordinates.to_vec(),
+        }
     }
 }
 

--- a/src/models/location.rs
+++ b/src/models/location.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use std::{collections::HashMap, fmt};
 
-use crate::service::ToHashMap;
+use crate::service::{Error, ToHashMap, Validator};
 
 use super::feature::Feature;
 
@@ -9,7 +9,7 @@ pub trait FormattedAddress {
     fn format() -> &'static str;
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ConvertTo3wa {
     coordinates: Option<Coordinates>,
     locale: Option<String>,
@@ -17,7 +17,7 @@ pub struct ConvertTo3wa {
 }
 
 impl ToHashMap for ConvertTo3wa {
-    fn to_hash_map<'a>(&self) -> HashMap<&'a str, String> {
+    fn to_hash_map<'a>(&self) -> Result<HashMap<&'a str, String>, Error> {
         let mut map = HashMap::new();
         if let Some(coordinates) = &self.coordinates {
             map.insert(
@@ -31,7 +31,7 @@ impl ToHashMap for ConvertTo3wa {
         if let Some(ref language) = &self.language {
             map.insert("language", language.into());
         }
-        map
+        Ok(map)
     }
 }
 
@@ -62,7 +62,7 @@ pub struct ConvertToCoordinates {
 }
 
 impl ToHashMap for ConvertToCoordinates {
-    fn to_hash_map<'a>(&self) -> HashMap<&'a str, String> {
+    fn to_hash_map<'a>(&self) -> Result<HashMap<&'a str, String>, Error> {
         let mut map = HashMap::new();
         if let Some(ref locale) = &self.locale {
             map.insert("locale", locale.into());
@@ -70,7 +70,7 @@ impl ToHashMap for ConvertToCoordinates {
         if let Some(ref words) = &self.words {
             map.insert("words", words.into());
         }
-        map
+        Ok(map)
     }
 }
 
@@ -87,7 +87,7 @@ impl ConvertToCoordinates {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Coordinates {
     pub lat: f64,
     pub lng: f64,
@@ -105,13 +105,76 @@ impl Coordinates {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+pub struct Circle {
+    lat: f64,
+    lng: f64,
+    radius: u32,
+}
+
+impl Circle {
+    pub fn new(lat: f64, lng: f64, radius: u32) -> Self {
+        Self { lat, lng, radius }
+    }
+}
+
+impl fmt::Display for Circle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{},{},{}", self.lat, self.lng, self.radius)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Polygon {
+    coordinates: Vec<Coordinates>,
+}
+
+impl Polygon {
+    pub fn new(coordinates: Vec<Coordinates>) -> Self {
+        Self { coordinates }
+    }
+}
+
+impl Validator for Polygon {
+    fn validate(&self) -> Result<(), Error> {
+        if self.coordinates.len() < 4 {
+            return Err(Error::InvalidParameter(
+                "A polygon must have at least 4 coordinates.",
+            ));
+        }
+        if self.coordinates.len() > 25 {
+            return Err(Error::InvalidParameter(
+                "A polygon must have no more than 25 coordinates.",
+            ));
+        }
+        if self.coordinates.first() != self.coordinates.last() {
+            return Err(Error::InvalidParameter(
+                "The first and last coordinates must be the same to form a closed polygon.",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Polygon {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let coords = self
+            .coordinates
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        write!(f, "{coords}")
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct Square {
     pub southwest: Coordinates,
     pub northeast: Coordinates,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Address {
     pub country: String,
     pub square: Square,
@@ -137,7 +200,7 @@ pub struct Geometry {
     pub kind: String,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct AddressGeoJson {
     pub features: Vec<Feature<Geometry>>,
     #[serde(rename = "type")]
@@ -168,21 +231,23 @@ mod location_tests {
         let convert = ConvertTo3wa::new(51.521251, -0.203586)
             .locale("en")
             .language("en");
-        let map = convert.to_hash_map();
-        assert_eq!(
-            map.get("coordinates"),
-            Some(&"51.521251,-0.203586".to_string())
-        );
-        assert_eq!(map.get("locale"), Some(&"en".to_string()));
-        assert_eq!(map.get("language"), Some(&"en".to_string()));
+        if let Ok(map) = convert.to_hash_map() {
+            assert_eq!(
+                map.get("coordinates"),
+                Some(&"51.521251,-0.203586".to_string())
+            );
+            assert_eq!(map.get("locale"), Some(&"en".to_string()));
+            assert_eq!(map.get("language"), Some(&"en".to_string()));
+        }
     }
 
     #[test]
     fn test_convert_to_coordinates_to_hash_map() {
         let convert = ConvertToCoordinates::new("index.home.raft").locale("en");
-        let map = convert.to_hash_map();
-        assert_eq!(map.get("locale"), Some(&"en".to_string()));
-        assert_eq!(map.get("words"), Some(&"index.home.raft".to_string()));
+        if let Ok(map) = convert.to_hash_map() {
+            assert_eq!(map.get("locale"), Some(&"en".to_string()));
+            assert_eq!(map.get("words"), Some(&"index.home.raft".to_string()));
+        }
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,8 +14,12 @@ use reqwest::Client;
 use serde::de::DeserializeOwned;
 use std::{collections::HashMap, env, fmt};
 
+pub(crate) trait Validator {
+    fn validate(&self) -> std::result::Result<(), Error>;
+}
+
 pub(crate) trait ToHashMap {
-    fn to_hash_map<'a>(&self) -> HashMap<&'a str, String>;
+    fn to_hash_map<'a>(&self) -> std::result::Result<HashMap<&'a str, String>, Error>;
 }
 
 #[derive(Debug)]
@@ -24,6 +28,7 @@ pub enum Error {
     Http(String),
     Api(String, String),
     Decode(String),
+    InvalidParameter(&'static str),
     Unknown(String),
 }
 
@@ -36,6 +41,7 @@ impl fmt::Display for Error {
                 write!(f, "W3W error: {} {}", code, message)
             }
             Error::Decode(msg) => write!(f, "Decode error: {}", msg),
+            Error::InvalidParameter(msg) => write!(f, "Invalid input: {}", msg),
             Error::Unknown(msg) => write!(f, "Unknown error: {}", msg),
         }
     }
@@ -110,7 +116,7 @@ impl What3words {
         options: &ConvertTo3wa,
     ) -> Result<T> {
         let url = format!("{}/convert-to-3wa", self.host);
-        let mut params = options.to_hash_map();
+        let mut params = options.to_hash_map()?;
         params.insert("format", T::format().to_string());
         self.request(url, Some(params))
     }
@@ -121,7 +127,7 @@ impl What3words {
         options: &ConvertTo3wa,
     ) -> Result<T> {
         let url = format!("{}/convert-to-3wa", self.host);
-        let mut params = options.to_hash_map();
+        let mut params = options.to_hash_map()?;
         params.insert("format", T::format().to_string());
         self.request(url, Some(params)).await
     }
@@ -132,7 +138,7 @@ impl What3words {
         options: &ConvertToCoordinates,
     ) -> Result<T> {
         let url = format!("{}/convert-to-coordinates", self.host);
-        let mut params = options.to_hash_map();
+        let mut params = options.to_hash_map()?;
         params.insert("format", T::format().to_string());
         self.request(url, Some(params))
     }
@@ -143,7 +149,7 @@ impl What3words {
         options: &ConvertToCoordinates,
     ) -> Result<T> {
         let url = format!("{}/convert-to-coordinates", self.host);
-        let mut params = options.to_hash_map();
+        let mut params = options.to_hash_map()?;
         params.insert("format", T::format().to_string());
         self.request(url, Some(params)).await
     }
@@ -186,14 +192,14 @@ impl What3words {
 
     #[cfg(feature = "sync")]
     pub fn autosuggest(&self, autosuggest: &Autosuggest) -> Result<AutosuggestResult> {
-        let params = autosuggest.clone().to_hash_map();
+        let params = autosuggest.clone().to_hash_map()?;
         let url = format!("{}/autosuggest", self.host);
         self.request(url, Some(params))
     }
 
     #[cfg(not(feature = "sync"))]
     pub async fn autosuggest(&self, autosuggest: &Autosuggest) -> Result<AutosuggestResult> {
-        let params = autosuggest.clone().to_hash_map();
+        let params = autosuggest.clone().to_hash_map()?;
         let url = format!("{}/autosuggest", self.host);
         self.request(url, Some(params)).await
     }
@@ -203,7 +209,7 @@ impl What3words {
         &self,
         autosuggest: &Autosuggest,
     ) -> Result<AutosuggestResult> {
-        let params = autosuggest.clone().to_hash_map();
+        let params = autosuggest.clone().to_hash_map()?;
         let url = format!("{}/autosuggest-with-coordinates", self.host);
         self.request(url, Some(params))
     }
@@ -213,21 +219,21 @@ impl What3words {
         &self,
         autosuggest: &Autosuggest,
     ) -> Result<AutosuggestResult> {
-        let params = autosuggest.clone().to_hash_map();
+        let params = autosuggest.clone().to_hash_map()?;
         let url = format!("{}/autosuggest-with-coordinates", self.host);
         self.request(url, Some(params)).await
     }
 
     #[cfg(feature = "sync")]
     pub fn autosuggest_selection(&self, selection: &AutosuggestSelection) -> Result<()> {
-        let params = selection.to_hash_map();
+        let params = selection.to_hash_map()?;
         let url = format!("{}/autosuggest-selection", self.host);
         self.request(url, Some(params))
     }
 
     #[cfg(not(feature = "sync"))]
     pub async fn autosuggest_selection(&self, selection: &AutosuggestSelection) -> Result<()> {
-        let params = selection.to_hash_map();
+        let params = selection.to_hash_map()?;
         let url = format!("{}/autosuggest-selection", self.host);
         self.request(url, Some(params)).await
     }


### PR DESCRIPTION
`Autosuggest` options has a couple of functions that allows you to set `clip_to_xxxx`, which currently accepts a string. Adding types/struct for this would be a good idea. Also `clip_to_polygon` has a couple of constraints/validation such as a minimum of 4 coordinates, and the first and last coordinate should be the same, as well as it should not exceed 25 coordinates, so a validation step should be good to add to cover this.